### PR TITLE
treat any imports with extensions (excluding html and [tj]sx?) as asset imports

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} **/
-import { createDefaultEsmPreset } from "ts-jest";
-
 export default {
   testEnvironment: "node",
-  ...createDefaultEsmPreset(),
-  moduleNameMapper: {
-    "^(\\.{1,2}/.*)\\.js$": "$1",
+  transform: {
+    "^.+.tsx?$": ["ts-jest", {}],
   },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,10 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} **/
+import { createDefaultEsmPreset } from "ts-jest";
+
 export default {
   testEnvironment: "node",
-  transform: {
-    "^.+.tsx?$": ["ts-jest", {}],
+  ...createDefaultEsmPreset(),
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
   },
 };

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/index.cjs",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     },
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
       "types": "./dist/types/index.d.ts",
       "import": "./dist/index.cjs",
       "require": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "keywords": [
     "esbuild",

--- a/src/documents.ts
+++ b/src/documents.ts
@@ -187,7 +187,10 @@ export function documentPlugin(args: DocumentPluginOptions): esbuild.Plugin {
             cwd: process.cwd(),
           });
 
-          const output = path.resolve(outdir, assetDir, basename(args.path));
+          const output = path.relative(
+            process.cwd(),
+            path.resolve(outdir, assetDir, basename(args.path)),
+          );
           const entrypoint = path.relative(process.cwd(), args.path);
 
           assets.push({ output, entrypoint });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -15,6 +15,7 @@ export interface MMLPluginOptions {
   outputProcessor?: OutputProcessorProvider;
   documentPrefix?: string;
   assetPrefix?: string;
+  assetDir?: string;
   importPrefix?: string;
 }
 
@@ -24,6 +25,7 @@ export function mml(args: MMLPluginOptions = {}): esbuild.Plugin {
     outputProcessor: outputProcessorProvider,
     importPrefix,
     assetPrefix = "",
+    assetDir = "assets",
   } = args;
   let { documentPrefix = "ws:///" } = args;
 
@@ -78,6 +80,7 @@ export function mml(args: MMLPluginOptions = {}): esbuild.Plugin {
       const documentCtx = await documentContext({
         build: build.esbuild,
         documents,
+        assetDir,
         options: initialOptions,
         onEnd: async (result, importStubs) => {
           processor.pushResult("document", result, importStubs);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -67,7 +67,7 @@ export function mml(args: MMLPluginOptions = {}): esbuild.Plugin {
         documents,
         options: initialOptions,
         onEnd: async (result, importStubs) => {
-          await onResult("document", result, importStubs);
+          await onResult("document", result, importStubs, false);
         },
         verbose,
       });
@@ -89,10 +89,6 @@ export function mml(args: MMLPluginOptions = {}): esbuild.Plugin {
       build.onStart(async () => {
         log("onStart");
         await worldCtx.rebuild();
-      });
-
-      build.onEnd(async (result) => {
-        await onResult("root", result, {});
       });
 
       build.onDispose(() => {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -24,7 +24,7 @@ export function mml(args: MMLPluginOptions = {}): esbuild.Plugin {
     verbose,
     outputProcessor: outputProcessorProvider,
     importPrefix,
-    assetPrefix = "",
+    assetPrefix = "/",
     assetDir = "assets",
   } = args;
   let { documentPrefix = "ws:///" } = args;

--- a/src/results.ts
+++ b/src/results.ts
@@ -40,6 +40,7 @@ export const makeResultProcessor = (
     key: string,
     result: esbuild.BuildResult,
     importStubs: Record<string, string>,
+    process = true,
   ) => {
     log("new result", util.inspect({ key, importStubs, result }, { depth: 5 }));
 
@@ -50,12 +51,16 @@ export const makeResultProcessor = (
 
     metaResults.set(key, { importStubs, result });
 
+    if (!process) {
+      return;
+    }
+
     const combinedResult = {} as esbuild.BuildResult;
     const combinedStubs = {} as Record<string, string>;
 
     for (const [, { importStubs, result }] of metaResults) {
-      merge(combinedResult, result);
-      merge(combinedStubs, importStubs);
+      merge(combinedResult, structuredClone(result));
+      merge(combinedStubs, structuredClone(importStubs));
     }
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/results.ts
+++ b/src/results.ts
@@ -85,16 +85,10 @@ export const makeResultProcessor = (
           }
           const entryPoint = meta.entryPoint ?? Object.keys(meta.inputs)[0];
           if (combinedStubs[entryPoint] && newImport !== entryPoint) {
+            log("Replacing import stub:", { entryPoint, newImport });
             combinedStubs[newImport] = combinedStubs[entryPoint];
             remove(combinedStubs, entryPoint);
           }
-          log("Output processor result", {
-            entryPoint,
-            result,
-            newPath,
-            newImport,
-            combinedStubs,
-          });
         }
 
         log("New stubs", combinedStubs);
@@ -128,7 +122,6 @@ export const makeResultProcessor = (
               stub,
               replacement,
               output,
-              contents,
             });
             contents = contents.replaceAll(stub, replacement);
           }

--- a/src/results.ts
+++ b/src/results.ts
@@ -63,6 +63,11 @@ export const makeResultProcessor = (
         merge(combinedStubs, structuredClone(importStubs));
       }
 
+      if (combinedResult.errors.length > 0) {
+        log("build failed with errors", combinedResult.errors);
+        return;
+      }
+
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const outputs = combinedResult.metafile!.outputs;
 

--- a/src/world.ts
+++ b/src/world.ts
@@ -36,7 +36,7 @@ export async function worldContext({
   const ctx = await build.context({
     ...options,
     entryPoints: worlds,
-    format: "esm",
+    format: "cjs",
     bundle: true,
     metafile: true,
     plugins: [

--- a/src/world.ts
+++ b/src/world.ts
@@ -36,7 +36,7 @@ export async function worldContext({
   const ctx = await build.context({
     ...options,
     entryPoints: worlds,
-    format: "cjs",
+    format: "esm",
     bundle: true,
     metafile: true,
     plugins: [
@@ -105,8 +105,7 @@ export async function worldContext({
             for (const [jsPath, meta] of Object.entries(outputs)) {
               if (!meta.entryPoint) continue;
               const jsonPath = jsPath.replace(jsExt, ".json");
-              // eslint-disable-next-line @typescript-eslint/no-require-imports
-              const { default: js } = require(path.resolve(jsPath)) as {
+              const { default: js } = (await import(path.resolve(jsPath))) as {
                 default: MMLWorldConfig;
               };
               const json = JSON.stringify(js, null, 2);

--- a/test/__snapshots__/test.ts.snap
+++ b/test/__snapshots__/test.ts.snap
@@ -6,7 +6,7 @@ exports[`context rebuild: generated/relative-outpath/context/rebuild/a.html/1 1`
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "duck.glb";
+  var duck_default = "assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
@@ -18,7 +18,7 @@ exports[`context rebuild: generated/relative-outpath/context/rebuild/a.html/2 1`
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "duck.glb";
+  var duck_default = "assets/duck.glb";
   var e_default = "ws:///e.html";
   console.log(b_default, d_default, duck_default);
   console.log(e_default);
@@ -32,11 +32,17 @@ exports[`context rebuild: generated/relative-outpath/context/rebuild/a.html/3 1`
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "duck.glb";
+  var duck_default = "assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
+
+exports[`context rebuild: generated/relative-outpath/context/rebuild/assets/duck.glb/1 1`] = `"duck.glb"`;
+
+exports[`context rebuild: generated/relative-outpath/context/rebuild/assets/duck.glb/2 1`] = `"duck.glb"`;
+
+exports[`context rebuild: generated/relative-outpath/context/rebuild/assets/duck.glb/3 1`] = `"duck.glb"`;
 
 exports[`context rebuild: generated/relative-outpath/context/rebuild/b.html/1 1`] = `
 "<body></body><script>"use strict";
@@ -92,12 +98,6 @@ exports[`context rebuild: generated/relative-outpath/context/rebuild/c/d.html/3 
 "
 `;
 
-exports[`context rebuild: generated/relative-outpath/context/rebuild/duck.glb/1 1`] = `"duck.glb"`;
-
-exports[`context rebuild: generated/relative-outpath/context/rebuild/duck.glb/2 1`] = `"duck.glb"`;
-
-exports[`context rebuild: generated/relative-outpath/context/rebuild/duck.glb/3 1`] = `"duck.glb"`;
-
 exports[`context rebuild: generated/relative-outpath/context/rebuild/e.html/2 1`] = `
 "<body></body><script>"use strict";
 (() => {
@@ -150,7 +150,7 @@ exports[`context watch: generated/relative-outpath/context/watch/a.html/1 1`] = 
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "duck.glb";
+  var duck_default = "assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
@@ -162,11 +162,15 @@ exports[`context watch: generated/relative-outpath/context/watch/a.html/2 1`] = 
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "duck.glb";
+  var duck_default = "assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
+
+exports[`context watch: generated/relative-outpath/context/watch/assets/duck.glb/1 1`] = `"duck.glb"`;
+
+exports[`context watch: generated/relative-outpath/context/watch/assets/duck.glb/2 1`] = `"duck.glb"`;
 
 exports[`context watch: generated/relative-outpath/context/watch/b.html/1 1`] = `
 "<body></body><script>"use strict";
@@ -203,10 +207,6 @@ exports[`context watch: generated/relative-outpath/context/watch/c/d.html/2 1`] 
 </html>
 "
 `;
-
-exports[`context watch: generated/relative-outpath/context/watch/duck.glb/1 1`] = `"duck.glb"`;
-
-exports[`context watch: generated/relative-outpath/context/watch/duck.glb/2 1`] = `"duck.glb"`;
 
 exports[`context watch: generated/relative-outpath/context/watch/world.json/1 1`] = `
 "{
@@ -252,6 +252,8 @@ exports[`documentContext creates MML HTML documents: generated/relative-outpath/
 "
 `;
 
+exports[`documentContext creates MML HTML documents: generated/relative-outpath/document-context/assets/duck.glb 1`] = `"duck.glb"`;
+
 exports[`documentContext creates MML HTML documents: generated/relative-outpath/document-context/b.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
@@ -279,19 +281,19 @@ exports[`documentContext creates MML HTML documents: generated/relative-outpath/
 "
 `;
 
-exports[`documentContext creates MML HTML documents: generated/relative-outpath/document-context/duck.glb 1`] = `"duck.glb"`;
-
 exports[`mml plugin with absolute outdir path with default options: generated/absolute-outpath/default-options/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "duck.glb";
+  var duck_default = "assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
+
+exports[`mml plugin with absolute outdir path with default options: generated/absolute-outpath/default-options/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with absolute outdir path with default options: generated/absolute-outpath/default-options/b.html 1`] = `
 "<body></body><script>"use strict";
@@ -311,19 +313,19 @@ exports[`mml plugin with absolute outdir path with default options: generated/ab
 "
 `;
 
-exports[`mml plugin with absolute outdir path with default options: generated/absolute-outpath/default-options/duck.glb 1`] = `"duck.glb"`;
-
 exports[`mml plugin with absolute outdir path with import prefix: generated/absolute-outpath/import-prefix/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "duck.glb";
+  var duck_default = "assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
+
+exports[`mml plugin with absolute outdir path with import prefix: generated/absolute-outpath/import-prefix/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with absolute outdir path with import prefix: generated/absolute-outpath/import-prefix/b.html 1`] = `
 "<body></body><script>"use strict";
@@ -343,19 +345,19 @@ exports[`mml plugin with absolute outdir path with import prefix: generated/abso
 "
 `;
 
-exports[`mml plugin with absolute outdir path with import prefix: generated/absolute-outpath/import-prefix/duck.glb 1`] = `"duck.glb"`;
-
 exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///blump/b.html";
   var d_default = "ws:///blump/c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "blump/duck.glb";
+  var duck_default = "blump/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
+
+exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/b.html 1`] = `
 "<body></body><script>"use strict";
@@ -375,19 +377,19 @@ exports[`mml plugin with absolute outdir path with new import and path from outp
 "
 `;
 
-exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/duck.glb 1`] = `"duck.glb"`;
-
 exports[`mml plugin with absolute outdir path with new import from output processor: generated/absolute-outpath/new-import/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///quux/b.html";
   var d_default = "ws:///quux/c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "quux/duck.glb";
+  var duck_default = "quux/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
+
+exports[`mml plugin with absolute outdir path with new import from output processor: generated/absolute-outpath/new-import/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with absolute outdir path with new import from output processor: generated/absolute-outpath/new-import/b.html 1`] = `
 "<body></body><script>"use strict";
@@ -407,19 +409,19 @@ exports[`mml plugin with absolute outdir path with new import from output proces
 "
 `;
 
-exports[`mml plugin with absolute outdir path with new import from output processor: generated/absolute-outpath/new-import/duck.glb 1`] = `"duck.glb"`;
-
 exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///bar/b.html";
   var d_default = "ws:///bar/c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "bar/duck.glb";
+  var duck_default = "bar/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
+
+exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/b.html 1`] = `
 "<body></body><script>"use strict";
@@ -439,19 +441,19 @@ exports[`mml plugin with absolute outdir path with new path from output processo
 "
 `;
 
-exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/duck.glb 1`] = `"duck.glb"`;
-
 exports[`mml plugin with absolute outdir path world: generated/absolute-outpath/world/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "duck.glb";
+  var duck_default = "assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
+
+exports[`mml plugin with absolute outdir path world: generated/absolute-outpath/world/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with absolute outdir path world: generated/absolute-outpath/world/b.html 1`] = `
 "<body></body><script>"use strict";
@@ -470,8 +472,6 @@ exports[`mml plugin with absolute outdir path world: generated/absolute-outpath/
 </html>
 "
 `;
-
-exports[`mml plugin with absolute outdir path world: generated/absolute-outpath/world/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with absolute outdir path world: generated/absolute-outpath/world/world.html 1`] = `
 "<body></body><script>"use strict";
@@ -494,11 +494,13 @@ exports[`mml plugin with relative outdir path with default options: generated/re
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "duck.glb";
+  var duck_default = "assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
+
+exports[`mml plugin with relative outdir path with default options: generated/relative-outpath/default-options/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with relative outdir path with default options: generated/relative-outpath/default-options/b.html 1`] = `
 "<body></body><script>"use strict";
@@ -518,19 +520,19 @@ exports[`mml plugin with relative outdir path with default options: generated/re
 "
 `;
 
-exports[`mml plugin with relative outdir path with default options: generated/relative-outpath/default-options/duck.glb 1`] = `"duck.glb"`;
-
 exports[`mml plugin with relative outdir path with import prefix: generated/relative-outpath/import-prefix/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "duck.glb";
+  var duck_default = "assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
+
+exports[`mml plugin with relative outdir path with import prefix: generated/relative-outpath/import-prefix/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with relative outdir path with import prefix: generated/relative-outpath/import-prefix/b.html 1`] = `
 "<body></body><script>"use strict";
@@ -550,19 +552,19 @@ exports[`mml plugin with relative outdir path with import prefix: generated/rela
 "
 `;
 
-exports[`mml plugin with relative outdir path with import prefix: generated/relative-outpath/import-prefix/duck.glb 1`] = `"duck.glb"`;
-
 exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///blump/b.html";
   var d_default = "ws:///blump/c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "blump/duck.glb";
+  var duck_default = "blump/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
+
+exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/b.html 1`] = `
 "<body></body><script>"use strict";
@@ -582,19 +584,19 @@ exports[`mml plugin with relative outdir path with new import and path from outp
 "
 `;
 
-exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/duck.glb 1`] = `"duck.glb"`;
-
 exports[`mml plugin with relative outdir path with new import from output processor: generated/relative-outpath/new-import/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///quux/b.html";
   var d_default = "ws:///quux/c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "quux/duck.glb";
+  var duck_default = "quux/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
+
+exports[`mml plugin with relative outdir path with new import from output processor: generated/relative-outpath/new-import/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with relative outdir path with new import from output processor: generated/relative-outpath/new-import/b.html 1`] = `
 "<body></body><script>"use strict";
@@ -614,19 +616,19 @@ exports[`mml plugin with relative outdir path with new import from output proces
 "
 `;
 
-exports[`mml plugin with relative outdir path with new import from output processor: generated/relative-outpath/new-import/duck.glb 1`] = `"duck.glb"`;
-
 exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///bar/b.html";
   var d_default = "ws:///bar/c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "bar/duck.glb";
+  var duck_default = "bar/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
+
+exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/b.html 1`] = `
 "<body></body><script>"use strict";
@@ -646,19 +648,19 @@ exports[`mml plugin with relative outdir path with new path from output processo
 "
 `;
 
-exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/duck.glb 1`] = `"duck.glb"`;
-
 exports[`mml plugin with relative outdir path world: generated/relative-outpath/world/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "duck.glb";
+  var duck_default = "assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
+
+exports[`mml plugin with relative outdir path world: generated/relative-outpath/world/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with relative outdir path world: generated/relative-outpath/world/b.html 1`] = `
 "<body></body><script>"use strict";
@@ -677,8 +679,6 @@ exports[`mml plugin with relative outdir path world: generated/relative-outpath/
 </html>
 "
 `;
-
-exports[`mml plugin with relative outdir path world: generated/relative-outpath/world/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with relative outdir path world: generated/relative-outpath/world/world.html 1`] = `
 "<body></body><script>"use strict";
@@ -701,34 +701,15 @@ exports[`resultProcessor re-writes import paths for documents: generated/relativ
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "http://duck.glb";
+  var duck_default = "http://assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
 
-exports[`resultProcessor re-writes import paths for documents: generated/relative-outpath/result-processor/world/a.html 2`] = `
-"<body></body><script>"use strict";
-(() => {
-  var b_default = "ws:///b.html";
-  var d_default = "ws:///c/d.html";
-  var c = "wat-" + d_default;
-  var duck_default = "http://duck.glb";
-  console.log(b_default, d_default, duck_default);
-})();
-</script>"
-`;
+exports[`resultProcessor re-writes import paths for documents: generated/relative-outpath/result-processor/world/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`resultProcessor re-writes import paths for documents: generated/relative-outpath/result-processor/world/b.html 1`] = `
-"<body></body><script>"use strict";
-(() => {
-  var d_default = "ws:///c/d.html";
-  var c = "wat-" + d_default;
-})();
-</script>"
-`;
-
-exports[`resultProcessor re-writes import paths for documents: generated/relative-outpath/result-processor/world/b.html 2`] = `
 "<body></body><script>"use strict";
 (() => {
   var d_default = "ws:///c/d.html";
@@ -745,19 +726,6 @@ exports[`resultProcessor re-writes import paths for documents: generated/relativ
 </html>
 "
 `;
-
-exports[`resultProcessor re-writes import paths for documents: generated/relative-outpath/result-processor/world/c/d.html 2`] = `
-"<html>
-  <body>
-    <p>I'm html!</p>
-  </body>
-</html>
-"
-`;
-
-exports[`resultProcessor re-writes import paths for documents: generated/relative-outpath/result-processor/world/duck.glb 1`] = `"duck.glb"`;
-
-exports[`resultProcessor re-writes import paths for documents: generated/relative-outpath/result-processor/world/duck.glb 2`] = `"duck.glb"`;
 
 exports[`worldContext creates world JSON: generated/relative-outpath/world-context/world.js 1`] = `
 ""use strict";

--- a/test/__snapshots__/test.ts.snap
+++ b/test/__snapshots__/test.ts.snap
@@ -320,7 +320,7 @@ exports[`mml plugin with absolute outdir path with import prefix: generated/abso
 "
 `;
 
-exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/flump/flump/a.html 1`] = `
+exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///blump/b.html";
@@ -331,7 +331,7 @@ exports[`mml plugin with absolute outdir path with new import and path from outp
 </script>"
 `;
 
-exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/flump/flump/b.html 1`] = `
+exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/b.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var d_default = "ws:///blump/c/d.html";
@@ -340,7 +340,7 @@ exports[`mml plugin with absolute outdir path with new import and path from outp
 </script>"
 `;
 
-exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/flump/flump/c/d.html 1`] = `
+exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/c/d.html 1`] = `
 "<html>
   <body>
     <p>I'm html!</p>
@@ -378,7 +378,7 @@ exports[`mml plugin with absolute outdir path with new import from output proces
 "
 `;
 
-exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/bar/bar/a.html 1`] = `
+exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///bar/b.html";
@@ -389,7 +389,7 @@ exports[`mml plugin with absolute outdir path with new path from output processo
 </script>"
 `;
 
-exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/bar/bar/b.html 1`] = `
+exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/b.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var d_default = "ws:///bar/c/d.html";
@@ -398,7 +398,7 @@ exports[`mml plugin with absolute outdir path with new path from output processo
 </script>"
 `;
 
-exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/bar/bar/c/d.html 1`] = `
+exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/c/d.html 1`] = `
 "<html>
   <body>
     <p>I'm html!</p>
@@ -509,7 +509,7 @@ exports[`mml plugin with relative outdir path with import prefix: generated/rela
 "
 `;
 
-exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/flump/flump/a.html 1`] = `
+exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///blump/b.html";
@@ -520,7 +520,7 @@ exports[`mml plugin with relative outdir path with new import and path from outp
 </script>"
 `;
 
-exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/flump/flump/b.html 1`] = `
+exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/b.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var d_default = "ws:///blump/c/d.html";
@@ -529,7 +529,7 @@ exports[`mml plugin with relative outdir path with new import and path from outp
 </script>"
 `;
 
-exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/flump/flump/c/d.html 1`] = `
+exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/c/d.html 1`] = `
 "<html>
   <body>
     <p>I'm html!</p>
@@ -567,7 +567,7 @@ exports[`mml plugin with relative outdir path with new import from output proces
 "
 `;
 
-exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/bar/bar/a.html 1`] = `
+exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///bar/b.html";
@@ -578,7 +578,7 @@ exports[`mml plugin with relative outdir path with new path from output processo
 </script>"
 `;
 
-exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/bar/bar/b.html 1`] = `
+exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/b.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var d_default = "ws:///bar/c/d.html";
@@ -587,7 +587,7 @@ exports[`mml plugin with relative outdir path with new path from output processo
 </script>"
 `;
 
-exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/bar/bar/c/d.html 1`] = `
+exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/c/d.html 1`] = `
 "<html>
   <body>
     <p>I'm html!</p>

--- a/test/__snapshots__/test.ts.snap
+++ b/test/__snapshots__/test.ts.snap
@@ -6,7 +6,7 @@ exports[`context rebuild: generated/relative-outpath/context/rebuild/a.html/1 1`
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "assets/duck.glb";
+  var duck_default = "/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
@@ -18,7 +18,7 @@ exports[`context rebuild: generated/relative-outpath/context/rebuild/a.html/2 1`
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "assets/duck.glb";
+  var duck_default = "/assets/duck.glb";
   var e_default = "ws:///e.html";
   console.log(b_default, d_default, duck_default);
   console.log(e_default);
@@ -32,7 +32,7 @@ exports[`context rebuild: generated/relative-outpath/context/rebuild/a.html/3 1`
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "assets/duck.glb";
+  var duck_default = "/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
@@ -150,7 +150,7 @@ exports[`context watch: generated/relative-outpath/context/watch/a.html/1 1`] = 
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "assets/duck.glb";
+  var duck_default = "/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
@@ -162,7 +162,7 @@ exports[`context watch: generated/relative-outpath/context/watch/a.html/2 1`] = 
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "assets/duck.glb";
+  var duck_default = "/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
@@ -287,7 +287,7 @@ exports[`mml plugin with absolute outdir path with default options: generated/ab
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "assets/duck.glb";
+  var duck_default = "/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
@@ -319,7 +319,7 @@ exports[`mml plugin with absolute outdir path with import prefix: generated/abso
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "assets/duck.glb";
+  var duck_default = "/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
@@ -353,7 +353,7 @@ exports[`mml plugin with absolute outdir path with new import and path from outp
   var b_default = "ws:///blump/b.html";
   var d_default = "ws:///blump/c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "blip/assets/duck.glb";
+  var duck_default = "/blip/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
@@ -383,7 +383,7 @@ exports[`mml plugin with absolute outdir path with new import from output proces
   var b_default = "ws:///quux/b.html";
   var d_default = "ws:///quux/c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "qack/assets/duck.glb";
+  var duck_default = "/qack/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
@@ -415,7 +415,7 @@ exports[`mml plugin with absolute outdir path with new path from output processo
   var b_default = "ws:///bar/b.html";
   var d_default = "ws:///bar/c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "baz/assets/duck.glb";
+  var duck_default = "/baz/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
@@ -447,7 +447,7 @@ exports[`mml plugin with absolute outdir path world: generated/absolute-outpath/
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "assets/duck.glb";
+  var duck_default = "/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
@@ -494,7 +494,7 @@ exports[`mml plugin with relative outdir path with default options: generated/re
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "assets/duck.glb";
+  var duck_default = "/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
@@ -526,7 +526,7 @@ exports[`mml plugin with relative outdir path with import prefix: generated/rela
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "assets/duck.glb";
+  var duck_default = "/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
@@ -560,7 +560,7 @@ exports[`mml plugin with relative outdir path with new import and path from outp
   var b_default = "ws:///blump/b.html";
   var d_default = "ws:///blump/c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "blip/assets/duck.glb";
+  var duck_default = "/blip/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
@@ -590,7 +590,7 @@ exports[`mml plugin with relative outdir path with new import from output proces
   var b_default = "ws:///quux/b.html";
   var d_default = "ws:///quux/c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "qack/assets/duck.glb";
+  var duck_default = "/qack/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
@@ -622,7 +622,7 @@ exports[`mml plugin with relative outdir path with new path from output processo
   var b_default = "ws:///bar/b.html";
   var d_default = "ws:///bar/c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "baz/assets/duck.glb";
+  var duck_default = "/baz/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
@@ -654,7 +654,7 @@ exports[`mml plugin with relative outdir path world: generated/relative-outpath/
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "assets/duck.glb";
+  var duck_default = "/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"

--- a/test/__snapshots__/test.ts.snap
+++ b/test/__snapshots__/test.ts.snap
@@ -345,19 +345,19 @@ exports[`mml plugin with absolute outdir path with import prefix: generated/abso
 "
 `;
 
+exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flop/assets/duck.glb 1`] = `"duck.glb"`;
+
 exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///blump/b.html";
   var d_default = "ws:///blump/c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "blump/assets/duck.glb";
+  var duck_default = "blip/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
-
-exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/b.html 1`] = `
 "<body></body><script>"use strict";
@@ -383,13 +383,11 @@ exports[`mml plugin with absolute outdir path with new import from output proces
   var b_default = "ws:///quux/b.html";
   var d_default = "ws:///quux/c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "quux/assets/duck.glb";
+  var duck_default = "qack/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
-
-exports[`mml plugin with absolute outdir path with new import from output processor: generated/absolute-outpath/new-import/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with absolute outdir path with new import from output processor: generated/absolute-outpath/new-import/b.html 1`] = `
 "<body></body><script>"use strict";
@@ -409,19 +407,19 @@ exports[`mml plugin with absolute outdir path with new import from output proces
 "
 `;
 
+exports[`mml plugin with absolute outdir path with new import from output processor: generated/absolute-outpath/new-import/qack/assets/duck.glb 1`] = `"duck.glb"`;
+
 exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///bar/b.html";
   var d_default = "ws:///bar/c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "bar/assets/duck.glb";
+  var duck_default = "baz/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
-
-exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/b.html 1`] = `
 "<body></body><script>"use strict";
@@ -440,6 +438,8 @@ exports[`mml plugin with absolute outdir path with new path from output processo
 </html>
 "
 `;
+
+exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/baz/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with absolute outdir path world: generated/absolute-outpath/world/a.html 1`] = `
 "<body></body><script>"use strict";
@@ -552,19 +552,19 @@ exports[`mml plugin with relative outdir path with import prefix: generated/rela
 "
 `;
 
+exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flop/assets/duck.glb 1`] = `"duck.glb"`;
+
 exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///blump/b.html";
   var d_default = "ws:///blump/c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "blump/assets/duck.glb";
+  var duck_default = "blip/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
-
-exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/b.html 1`] = `
 "<body></body><script>"use strict";
@@ -590,13 +590,11 @@ exports[`mml plugin with relative outdir path with new import from output proces
   var b_default = "ws:///quux/b.html";
   var d_default = "ws:///quux/c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "quux/assets/duck.glb";
+  var duck_default = "qack/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
-
-exports[`mml plugin with relative outdir path with new import from output processor: generated/relative-outpath/new-import/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with relative outdir path with new import from output processor: generated/relative-outpath/new-import/b.html 1`] = `
 "<body></body><script>"use strict";
@@ -616,19 +614,19 @@ exports[`mml plugin with relative outdir path with new import from output proces
 "
 `;
 
+exports[`mml plugin with relative outdir path with new import from output processor: generated/relative-outpath/new-import/qack/assets/duck.glb 1`] = `"duck.glb"`;
+
 exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///bar/b.html";
   var d_default = "ws:///bar/c/d.html";
   var c = "wat-" + d_default;
-  var duck_default = "bar/assets/duck.glb";
+  var duck_default = "baz/assets/duck.glb";
   console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
-
-exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/b.html 1`] = `
 "<body></body><script>"use strict";
@@ -647,6 +645,8 @@ exports[`mml plugin with relative outdir path with new path from output processo
 </html>
 "
 `;
+
+exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/baz/assets/duck.glb 1`] = `"duck.glb"`;
 
 exports[`mml plugin with relative outdir path world: generated/relative-outpath/world/a.html 1`] = `
 "<body></body><script>"use strict";

--- a/test/__snapshots__/test.ts.snap
+++ b/test/__snapshots__/test.ts.snap
@@ -6,7 +6,8 @@ exports[`context rebuild: generated/relative-outpath/context/rebuild/a.html/1 1`
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  console.log(b_default, d_default);
+  var duck_default = "duck.glb";
+  console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
@@ -17,8 +18,9 @@ exports[`context rebuild: generated/relative-outpath/context/rebuild/a.html/2 1`
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
+  var duck_default = "duck.glb";
   var e_default = "ws:///e.html";
-  console.log(b_default, d_default);
+  console.log(b_default, d_default, duck_default);
   console.log(e_default);
 })();
 </script>"
@@ -30,7 +32,8 @@ exports[`context rebuild: generated/relative-outpath/context/rebuild/a.html/3 1`
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  console.log(b_default, d_default);
+  var duck_default = "duck.glb";
+  console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
@@ -89,6 +92,12 @@ exports[`context rebuild: generated/relative-outpath/context/rebuild/c/d.html/3 
 "
 `;
 
+exports[`context rebuild: generated/relative-outpath/context/rebuild/duck.glb/1 1`] = `"duck.glb"`;
+
+exports[`context rebuild: generated/relative-outpath/context/rebuild/duck.glb/2 1`] = `"duck.glb"`;
+
+exports[`context rebuild: generated/relative-outpath/context/rebuild/duck.glb/3 1`] = `"duck.glb"`;
+
 exports[`context rebuild: generated/relative-outpath/context/rebuild/e.html/2 1`] = `
 "<body></body><script>"use strict";
 (() => {
@@ -141,7 +150,8 @@ exports[`context watch: generated/relative-outpath/context/watch/a.html/1 1`] = 
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  console.log(b_default, d_default);
+  var duck_default = "duck.glb";
+  console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
@@ -152,7 +162,8 @@ exports[`context watch: generated/relative-outpath/context/watch/a.html/2 1`] = 
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  console.log(b_default, d_default);
+  var duck_default = "duck.glb";
+  console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
@@ -193,6 +204,10 @@ exports[`context watch: generated/relative-outpath/context/watch/c/d.html/2 1`] 
 "
 `;
 
+exports[`context watch: generated/relative-outpath/context/watch/duck.glb/1 1`] = `"duck.glb"`;
+
+exports[`context watch: generated/relative-outpath/context/watch/duck.glb/2 1`] = `"duck.glb"`;
+
 exports[`context watch: generated/relative-outpath/context/watch/world.json/1 1`] = `
 "{
   "mmlDocuments": {
@@ -219,7 +234,8 @@ exports[`documentContext creates MML HTML documents: generated/relative-outpath/
   var b_default = "mml:test/src/b.ts";
   var d_default = "mml:test/src/c/d.html";
   var c = "wat-" + d_default;
-  console.log(b_default, d_default);
+  var duck_default = "asset:test/src/duck.glb";
+  console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
@@ -230,7 +246,8 @@ exports[`documentContext creates MML HTML documents: generated/relative-outpath/
   var b_default = "mml:test/src/b.ts";
   var d_default = "mml:test/src/c/d.html";
   var c = "wat-" + d_default;
-  console.log(b_default, d_default);
+  var duck_default = "asset:test/src/duck.glb";
+  console.log(b_default, d_default, duck_default);
 })();
 "
 `;
@@ -262,13 +279,16 @@ exports[`documentContext creates MML HTML documents: generated/relative-outpath/
 "
 `;
 
+exports[`documentContext creates MML HTML documents: generated/relative-outpath/document-context/duck.glb 1`] = `"duck.glb"`;
+
 exports[`mml plugin with absolute outdir path with default options: generated/absolute-outpath/default-options/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  console.log(b_default, d_default);
+  var duck_default = "duck.glb";
+  console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
@@ -291,13 +311,16 @@ exports[`mml plugin with absolute outdir path with default options: generated/ab
 "
 `;
 
+exports[`mml plugin with absolute outdir path with default options: generated/absolute-outpath/default-options/duck.glb 1`] = `"duck.glb"`;
+
 exports[`mml plugin with absolute outdir path with import prefix: generated/absolute-outpath/import-prefix/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
-  var b_default = "foo/b.html";
-  var d_default = "foo/c/d.html";
+  var b_default = "ws:///b.html";
+  var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  console.log(b_default, d_default);
+  var duck_default = "duck.glb";
+  console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
@@ -305,7 +328,7 @@ exports[`mml plugin with absolute outdir path with import prefix: generated/abso
 exports[`mml plugin with absolute outdir path with import prefix: generated/absolute-outpath/import-prefix/b.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
-  var d_default = "foo/c/d.html";
+  var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
 })();
 </script>"
@@ -320,13 +343,16 @@ exports[`mml plugin with absolute outdir path with import prefix: generated/abso
 "
 `;
 
+exports[`mml plugin with absolute outdir path with import prefix: generated/absolute-outpath/import-prefix/duck.glb 1`] = `"duck.glb"`;
+
 exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///blump/b.html";
   var d_default = "ws:///blump/c/d.html";
   var c = "wat-" + d_default;
-  console.log(b_default, d_default);
+  var duck_default = "blump/duck.glb";
+  console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
@@ -349,13 +375,16 @@ exports[`mml plugin with absolute outdir path with new import and path from outp
 "
 `;
 
+exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/duck.glb 1`] = `"duck.glb"`;
+
 exports[`mml plugin with absolute outdir path with new import from output processor: generated/absolute-outpath/new-import/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///quux/b.html";
   var d_default = "ws:///quux/c/d.html";
   var c = "wat-" + d_default;
-  console.log(b_default, d_default);
+  var duck_default = "quux/duck.glb";
+  console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
@@ -378,13 +407,16 @@ exports[`mml plugin with absolute outdir path with new import from output proces
 "
 `;
 
+exports[`mml plugin with absolute outdir path with new import from output processor: generated/absolute-outpath/new-import/duck.glb 1`] = `"duck.glb"`;
+
 exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///bar/b.html";
   var d_default = "ws:///bar/c/d.html";
   var c = "wat-" + d_default;
-  console.log(b_default, d_default);
+  var duck_default = "bar/duck.glb";
+  console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
@@ -407,13 +439,16 @@ exports[`mml plugin with absolute outdir path with new path from output processo
 "
 `;
 
+exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/duck.glb 1`] = `"duck.glb"`;
+
 exports[`mml plugin with absolute outdir path world: generated/absolute-outpath/world/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  console.log(b_default, d_default);
+  var duck_default = "duck.glb";
+  console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
@@ -436,6 +471,8 @@ exports[`mml plugin with absolute outdir path world: generated/absolute-outpath/
 "
 `;
 
+exports[`mml plugin with absolute outdir path world: generated/absolute-outpath/world/duck.glb 1`] = `"duck.glb"`;
+
 exports[`mml plugin with absolute outdir path world: generated/absolute-outpath/world/world.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
@@ -457,7 +494,8 @@ exports[`mml plugin with relative outdir path with default options: generated/re
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  console.log(b_default, d_default);
+  var duck_default = "duck.glb";
+  console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
@@ -480,13 +518,16 @@ exports[`mml plugin with relative outdir path with default options: generated/re
 "
 `;
 
+exports[`mml plugin with relative outdir path with default options: generated/relative-outpath/default-options/duck.glb 1`] = `"duck.glb"`;
+
 exports[`mml plugin with relative outdir path with import prefix: generated/relative-outpath/import-prefix/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
-  var b_default = "foo/b.html";
-  var d_default = "foo/c/d.html";
+  var b_default = "ws:///b.html";
+  var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  console.log(b_default, d_default);
+  var duck_default = "duck.glb";
+  console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
@@ -494,7 +535,7 @@ exports[`mml plugin with relative outdir path with import prefix: generated/rela
 exports[`mml plugin with relative outdir path with import prefix: generated/relative-outpath/import-prefix/b.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
-  var d_default = "foo/c/d.html";
+  var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
 })();
 </script>"
@@ -509,13 +550,16 @@ exports[`mml plugin with relative outdir path with import prefix: generated/rela
 "
 `;
 
+exports[`mml plugin with relative outdir path with import prefix: generated/relative-outpath/import-prefix/duck.glb 1`] = `"duck.glb"`;
+
 exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///blump/b.html";
   var d_default = "ws:///blump/c/d.html";
   var c = "wat-" + d_default;
-  console.log(b_default, d_default);
+  var duck_default = "blump/duck.glb";
+  console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
@@ -538,13 +582,16 @@ exports[`mml plugin with relative outdir path with new import and path from outp
 "
 `;
 
+exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/duck.glb 1`] = `"duck.glb"`;
+
 exports[`mml plugin with relative outdir path with new import from output processor: generated/relative-outpath/new-import/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///quux/b.html";
   var d_default = "ws:///quux/c/d.html";
   var c = "wat-" + d_default;
-  console.log(b_default, d_default);
+  var duck_default = "quux/duck.glb";
+  console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
@@ -567,13 +614,16 @@ exports[`mml plugin with relative outdir path with new import from output proces
 "
 `;
 
+exports[`mml plugin with relative outdir path with new import from output processor: generated/relative-outpath/new-import/duck.glb 1`] = `"duck.glb"`;
+
 exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///bar/b.html";
   var d_default = "ws:///bar/c/d.html";
   var c = "wat-" + d_default;
-  console.log(b_default, d_default);
+  var duck_default = "bar/duck.glb";
+  console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
@@ -596,13 +646,16 @@ exports[`mml plugin with relative outdir path with new path from output processo
 "
 `;
 
+exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/duck.glb 1`] = `"duck.glb"`;
+
 exports[`mml plugin with relative outdir path world: generated/relative-outpath/world/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///b.html";
   var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  console.log(b_default, d_default);
+  var duck_default = "duck.glb";
+  console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
@@ -625,6 +678,8 @@ exports[`mml plugin with relative outdir path world: generated/relative-outpath/
 "
 `;
 
+exports[`mml plugin with relative outdir path world: generated/relative-outpath/world/duck.glb 1`] = `"duck.glb"`;
+
 exports[`mml plugin with relative outdir path world: generated/relative-outpath/world/world.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
@@ -643,10 +698,23 @@ exports[`mml plugin with relative outdir path world: generated/relative-outpath/
 exports[`resultProcessor re-writes import paths for documents: generated/relative-outpath/result-processor/world/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
-  var b_default = "wss://b.html";
-  var d_default = "wss://c/d.html";
+  var b_default = "ws:///b.html";
+  var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
-  console.log(b_default, d_default);
+  var duck_default = "http://duck.glb";
+  console.log(b_default, d_default, duck_default);
+})();
+</script>"
+`;
+
+exports[`resultProcessor re-writes import paths for documents: generated/relative-outpath/result-processor/world/a.html 2`] = `
+"<body></body><script>"use strict";
+(() => {
+  var b_default = "ws:///b.html";
+  var d_default = "ws:///c/d.html";
+  var c = "wat-" + d_default;
+  var duck_default = "http://duck.glb";
+  console.log(b_default, d_default, duck_default);
 })();
 </script>"
 `;
@@ -654,7 +722,16 @@ exports[`resultProcessor re-writes import paths for documents: generated/relativ
 exports[`resultProcessor re-writes import paths for documents: generated/relative-outpath/result-processor/world/b.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
-  var d_default = "wss://c/d.html";
+  var d_default = "ws:///c/d.html";
+  var c = "wat-" + d_default;
+})();
+</script>"
+`;
+
+exports[`resultProcessor re-writes import paths for documents: generated/relative-outpath/result-processor/world/b.html 2`] = `
+"<body></body><script>"use strict";
+(() => {
+  var d_default = "ws:///c/d.html";
   var c = "wat-" + d_default;
 })();
 </script>"
@@ -669,15 +746,18 @@ exports[`resultProcessor re-writes import paths for documents: generated/relativ
 "
 `;
 
-exports[`resultProcessor re-writes import paths for worlds: generated/relative-outpath/result-processor/world/world.json 1`] = `
-"{
-  "mmlDocuments": {
-    "duck": {
-      "url": "wss://test/src/a.ts"
-    }
-  }
-}"
+exports[`resultProcessor re-writes import paths for documents: generated/relative-outpath/result-processor/world/c/d.html 2`] = `
+"<html>
+  <body>
+    <p>I'm html!</p>
+  </body>
+</html>
+"
 `;
+
+exports[`resultProcessor re-writes import paths for documents: generated/relative-outpath/result-processor/world/duck.glb 1`] = `"duck.glb"`;
+
+exports[`resultProcessor re-writes import paths for documents: generated/relative-outpath/result-processor/world/duck.glb 2`] = `"duck.glb"`;
 
 exports[`worldContext creates world JSON: generated/relative-outpath/world-context/world.js 1`] = `
 ""use strict";

--- a/test/src/.gitattributes
+++ b/test/src/.gitattributes
@@ -1,0 +1,1 @@
+duck.glb filter=lfs diff=lfs merge=lfs -text

--- a/test/src/a.ts
+++ b/test/src/a.ts
@@ -1,4 +1,5 @@
 import b from "mml:./b";
 import { d } from "./b";
+import duck from "./duck.glb";
 
-console.log(b, d);
+console.log(b, d, duck);

--- a/test/src/duck.glb
+++ b/test/src/duck.glb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65bf938f54d6073e619e76e007820bbf980cdc3dc0daec0d94830ffc4ae54ab5
+size 120484

--- a/test/src/package.json
+++ b/test/src/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/src/types.d.ts
+++ b/test/src/types.d.ts
@@ -1,0 +1,4 @@
+declare module "*.glb" {
+  const value: string;
+  export default value;
+}

--- a/test/test.ts
+++ b/test/test.ts
@@ -115,8 +115,6 @@ describe("resultProcessor", () => {
       },
     });
 
-    await ctx.rebuild();
-
     expect.hasAssertions();
   });
 });

--- a/test/test.ts
+++ b/test/test.ts
@@ -105,6 +105,7 @@ describe("resultProcessor", () => {
     ctx = await documentContext({
       documents: ["test/src/a.ts"],
       options: { outdir },
+      assetDir: "assets",
       onEnd: async (result, importStubs) => {
         processor.pushResult("document", result, importStubs);
         await processor.process();
@@ -132,6 +133,7 @@ describe("documentContext", () => {
     ctx = await documentContext({
       documents: ["test/src/a.ts"],
       options: { outdir },
+      assetDir: "assets",
       onEnd: async (_result, importStubs) => {
         for await (const { path, content } of walk(outdir)) {
           expect(content).toMatchSnapshot(path);
@@ -215,7 +217,6 @@ describe("mml plugin", () => {
         entryPoints: ["mml:test/src/a.ts"],
         plugins: [
           mml({
-            verbose: true,
             outputProcessor: () => ({
               onOutput(output) {
                 return { path: path.join("bar/", output) };

--- a/test/test.ts
+++ b/test/test.ts
@@ -221,6 +221,9 @@ describe("mml plugin", () => {
               onOutput(output) {
                 return { path: path.join("bar/", output) };
               },
+              onAsset(asset) {
+                return { path: path.join("baz/", asset) };
+              },
             }),
           }),
         ],
@@ -250,6 +253,9 @@ describe("mml plugin", () => {
                   importStr: "quux/" + output,
                 };
               },
+              onAsset(asset) {
+                return { path: path.join("qack/", asset) };
+              },
             }),
           }),
         ],
@@ -275,6 +281,12 @@ describe("mml plugin", () => {
                 return {
                   path: "flump/" + output,
                   importStr: "blump/" + output,
+                };
+              },
+              onAsset(asset) {
+                return {
+                  path: path.join("flop/", asset),
+                  importStr: "blip/" + asset,
                 };
               },
             }),


### PR DESCRIPTION
handle importing assets into documents

Any imports that have an extension (exluding html, js, ts, jsx, and tsx), are
treated as assets. They are copied to the output directory and imports are re-written
using the `assetPrefix` argument.

This commit also fixes excessive output processing and as well as a bug that caused directory
re-writes to be recursive!

Finally, the `importPrefox` plugin argument is deprecated in favour of `docmentPrefix`.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe its impact and migration path for existing applications:

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
- [ ] The title references the corresponding issue # (if relevant)
