### PR TITLE
Prevent output paths from being recursively renamed

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/index.cjs",
-      "require": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     },
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
       "types": "./dist/types/index.d.ts",
       "import": "./dist/index.cjs",
       "require": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "keywords": [
     "esbuild",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -67,7 +67,7 @@ export function mml(args: MMLPluginOptions = {}): esbuild.Plugin {
         documents,
         options: initialOptions,
         onEnd: async (result, importStubs) => {
-          await onResult("document", result, importStubs);
+          await onResult("document", result, importStubs, false);
         },
         verbose,
       });
@@ -89,10 +89,6 @@ export function mml(args: MMLPluginOptions = {}): esbuild.Plugin {
       build.onStart(async () => {
         log("onStart");
         await worldCtx.rebuild();
-      });
-
-      build.onEnd(async (result) => {
-        await onResult("root", result, {});
       });
 
       build.onDispose(() => {

--- a/src/results.ts
+++ b/src/results.ts
@@ -40,6 +40,7 @@ export const makeResultProcessor = (
     key: string,
     result: esbuild.BuildResult,
     importStubs: Record<string, string>,
+    process = true,
   ) => {
     log("new result", util.inspect({ key, importStubs, result }, { depth: 5 }));
 
@@ -50,12 +51,16 @@ export const makeResultProcessor = (
 
     metaResults.set(key, { importStubs, result });
 
+    if (!process) {
+      return;
+    }
+
     const combinedResult = {} as esbuild.BuildResult;
     const combinedStubs = {} as Record<string, string>;
 
     for (const [, { importStubs, result }] of metaResults) {
-      merge(combinedResult, result);
-      merge(combinedStubs, importStubs);
+      merge(combinedResult, structuredClone(result));
+      merge(combinedStubs, structuredClone(importStubs));
     }
 
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/results.ts
+++ b/src/results.ts
@@ -85,16 +85,10 @@ export const makeResultProcessor = (
           }
           const entryPoint = meta.entryPoint ?? Object.keys(meta.inputs)[0];
           if (combinedStubs[entryPoint] && newImport !== entryPoint) {
+            log("Replacing import stub:", { entryPoint, newImport });
             combinedStubs[newImport] = combinedStubs[entryPoint];
             remove(combinedStubs, entryPoint);
           }
-          log("Output processor result", {
-            entryPoint,
-            result,
-            newPath,
-            newImport,
-            combinedStubs,
-          });
         }
 
         log("New stubs", combinedStubs);
@@ -128,7 +122,6 @@ export const makeResultProcessor = (
               stub,
               replacement,
               output,
-              contents,
             });
             contents = contents.replaceAll(stub, replacement);
           }

--- a/src/results.ts
+++ b/src/results.ts
@@ -63,6 +63,11 @@ export const makeResultProcessor = (
         merge(combinedStubs, structuredClone(importStubs));
       }
 
+      if (combinedResult.errors.length > 0) {
+        log("build failed with errors", combinedResult.errors);
+        return;
+      }
+
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const outputs = combinedResult.metafile!.outputs;
 

--- a/src/world.ts
+++ b/src/world.ts
@@ -36,7 +36,7 @@ export async function worldContext({
   const ctx = await build.context({
     ...options,
     entryPoints: worlds,
-    format: "esm",
+    format: "cjs",
     bundle: true,
     metafile: true,
     plugins: [

--- a/src/world.ts
+++ b/src/world.ts
@@ -36,7 +36,7 @@ export async function worldContext({
   const ctx = await build.context({
     ...options,
     entryPoints: worlds,
-    format: "cjs",
+    format: "esm",
     bundle: true,
     metafile: true,
     plugins: [
@@ -105,8 +105,7 @@ export async function worldContext({
             for (const [jsPath, meta] of Object.entries(outputs)) {
               if (!meta.entryPoint) continue;
               const jsonPath = jsPath.replace(jsExt, ".json");
-              // eslint-disable-next-line @typescript-eslint/no-require-imports
-              const { default: js } = require(path.resolve(jsPath)) as {
+              const { default: js } = (await import(path.resolve(jsPath))) as {
                 default: MMLWorldConfig;
               };
               const json = JSON.stringify(js, null, 2);

--- a/test/__snapshots__/test.ts.snap
+++ b/test/__snapshots__/test.ts.snap
@@ -320,7 +320,7 @@ exports[`mml plugin with absolute outdir path with import prefix: generated/abso
 "
 `;
 
-exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/flump/flump/a.html 1`] = `
+exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///blump/b.html";
@@ -331,7 +331,7 @@ exports[`mml plugin with absolute outdir path with new import and path from outp
 </script>"
 `;
 
-exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/flump/flump/b.html 1`] = `
+exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/b.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var d_default = "ws:///blump/c/d.html";
@@ -340,7 +340,7 @@ exports[`mml plugin with absolute outdir path with new import and path from outp
 </script>"
 `;
 
-exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/flump/flump/c/d.html 1`] = `
+exports[`mml plugin with absolute outdir path with new import and path from output processor: generated/absolute-outpath/new-import-and-path/flump/c/d.html 1`] = `
 "<html>
   <body>
     <p>I'm html!</p>
@@ -378,7 +378,7 @@ exports[`mml plugin with absolute outdir path with new import from output proces
 "
 `;
 
-exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/bar/bar/a.html 1`] = `
+exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///bar/b.html";
@@ -389,7 +389,7 @@ exports[`mml plugin with absolute outdir path with new path from output processo
 </script>"
 `;
 
-exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/bar/bar/b.html 1`] = `
+exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/b.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var d_default = "ws:///bar/c/d.html";
@@ -398,7 +398,7 @@ exports[`mml plugin with absolute outdir path with new path from output processo
 </script>"
 `;
 
-exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/bar/bar/c/d.html 1`] = `
+exports[`mml plugin with absolute outdir path with new path from output processor: generated/absolute-outpath/new-path/bar/c/d.html 1`] = `
 "<html>
   <body>
     <p>I'm html!</p>
@@ -509,7 +509,7 @@ exports[`mml plugin with relative outdir path with import prefix: generated/rela
 "
 `;
 
-exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/flump/flump/a.html 1`] = `
+exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///blump/b.html";
@@ -520,7 +520,7 @@ exports[`mml plugin with relative outdir path with new import and path from outp
 </script>"
 `;
 
-exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/flump/flump/b.html 1`] = `
+exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/b.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var d_default = "ws:///blump/c/d.html";
@@ -529,7 +529,7 @@ exports[`mml plugin with relative outdir path with new import and path from outp
 </script>"
 `;
 
-exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/flump/flump/c/d.html 1`] = `
+exports[`mml plugin with relative outdir path with new import and path from output processor: generated/relative-outpath/new-import-and-path/flump/c/d.html 1`] = `
 "<html>
   <body>
     <p>I'm html!</p>
@@ -567,7 +567,7 @@ exports[`mml plugin with relative outdir path with new import from output proces
 "
 `;
 
-exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/bar/bar/a.html 1`] = `
+exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/a.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var b_default = "ws:///bar/b.html";
@@ -578,7 +578,7 @@ exports[`mml plugin with relative outdir path with new path from output processo
 </script>"
 `;
 
-exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/bar/bar/b.html 1`] = `
+exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/b.html 1`] = `
 "<body></body><script>"use strict";
 (() => {
   var d_default = "ws:///bar/c/d.html";
@@ -587,7 +587,7 @@ exports[`mml plugin with relative outdir path with new path from output processo
 </script>"
 `;
 
-exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/bar/bar/c/d.html 1`] = `
+exports[`mml plugin with relative outdir path with new path from output processor: generated/relative-outpath/new-path/bar/c/d.html 1`] = `
 "<html>
   <body>
     <p>I'm html!</p>

--- a/test/src/package.json
+++ b/test/src/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
Previously when combining the build result outputs, we were merging object references, which meant that we were directly mutating the source when re-writing the output file paths. This caused file paths to be recursively renamed when the result processor ran multiple times (e.g. in watch mode). This is fixed by merging `structuredClones` of the each result, so that we mutate a copy, rather than the original data.

---

**What kind of changes does your PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Tests
- [ ] Other, please describe:

**Does your PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe its impact and migration path for existing applications:

**Does your PR fulfill the following requirements?**

- [x] All tests are passing
- [ ] The title references the corresponding issue # (if relevant)
